### PR TITLE
Update from original. Added 'attachments:' parameter to -[CBLDocument putExistingRevision...]

### DIFF
--- a/Source/API/CBLDocument.h
+++ b/Source/API/CBLDocument.h
@@ -116,6 +116,9 @@ NS_ASSUME_NONNULL_BEGIN
     implementing some new kind of replicator that transfers revisions from another database.
     @param properties  The properties of the revision (_id and _rev will be ignored, but _deleted
                     and _attachments are recognized.)
+    @param attachments  A dictionary providing attachment bodies. The keys are the attachment
+                    names (matching the keys in the properties' `_attachments` dictionary) and
+                    the values are the attachment bodies as NSData or NSURL.
     @param revIDs  The revision history in the form of an array of revision-ID strings, in
                     reverse chronological order. The first item must be the new revision's ID.
                     Following items are its parent's ID, etc.
@@ -124,7 +127,8 @@ NS_ASSUME_NONNULL_BEGIN
                     decide whether the change is local or not.)
     @param outError  Error information will be stored here if the insertion fails.
     @return  YES on success, NO on failure. */
-- (BOOL) putExistingRevisionWithProperties: (NSDictionary*)properties
+- (BOOL) putExistingRevisionWithProperties: (CBLJSONDict*)properties
+                               attachments: (nullable NSDictionary*)attachments
                            revisionHistory: (CBLArrayOf(NSString*)*)revIDs
                                    fromURL: (nullable NSURL*)sourceURL
                                      error: (NSError**)outError;

--- a/Source/API/CBLDocument.m
+++ b/Source/API/CBLDocument.m
@@ -315,7 +315,8 @@ NSString* const kCBLDocumentChangeNotification = @"CBLDocumentChange";
     return nil;
 }
 
-- (BOOL) putExistingRevisionWithProperties: (NSDictionary*)properties
+- (BOOL) putExistingRevisionWithProperties: (CBLJSONDict*)properties
+                               attachments: (NSDictionary*)attachments
                            revisionHistory: (NSArray*)revIDs
                                    fromURL: (NSURL*)sourceURL
                                      error: (NSError**)outError
@@ -325,6 +326,8 @@ NSString* const kCBLDocumentChangeNotification = @"CBLDocumentChange";
                                                                     revID: revIDs[0]
                                                                   deleted: properties.cbl_deleted];
     rev.properties = [self propertiesToInsert: properties];
+    if (![_database registerAttachmentBodies: attachments forRevision: rev error: outError])
+        return NO;
     CBLStatus status = [_database forceInsert: rev
                               revisionHistory: revIDs
                                        source: sourceURL

--- a/Source/CBLDatabase+Attachments.h
+++ b/Source/CBLDatabase+Attachments.h
@@ -24,6 +24,13 @@ typedef enum {
 
 + (NSString*) blobKeyToDigest: (CBLBlobKey)key;
 
+/** Register attachment bodies in `attachments` (NSData or file NSURLs) corresponding to the
+    attachments in `rev`. The _attachments dict will be mutated if necessary to add "digest"
+    and "follows" properties. */
+- (BOOL) registerAttachmentBodies: (NSDictionary*)attachments
+                      forRevision: (CBL_MutableRevision*)rev
+                            error: (NSError**)outError;
+
 /** Scans the rev's _attachments dictionary, adding inline attachment data to the blob-store
     and turning all the attachments into stubs. */
 - (BOOL) processAttachmentsForRevision: (CBL_MutableRevision*)rev

--- a/Unit-Tests/Database_Tests.m
+++ b/Unit-Tests/Database_Tests.m
@@ -350,6 +350,7 @@
 
     NSError* error;
     Assert(([doc putExistingRevisionWithProperties: @{@"foo": @2}
+                                       attachments: nil
                                    revisionHistory: @[@"3-cafebabe", @"2-feedba95", doc.currentRevisionID]
                                            fromURL: nil
                                              error: &error]));
@@ -362,12 +363,14 @@
 
     // Repeat; should be no error:
     Assert(([doc putExistingRevisionWithProperties: @{@"foo": @2}
+                                       attachments: nil
                                    revisionHistory: @[@"3-cafebabe", @"2-feedba95", doc.currentRevisionID]
                                            fromURL: nil
                                              error: &error]));
 
     // Add a deleted revision:
     Assert(([doc putExistingRevisionWithProperties: @{@"foo": @-1, @"_deleted": @YES}
+                                       attachments: nil
                                    revisionHistory: @[@"3-deadbeef", @"2-feedba95", doc.currentRevisionID]
                                            fromURL: nil
                                              error: &error]));
@@ -378,6 +381,31 @@
                                    @"_rev": @"3-deadbeef",
                                    @"_deleted": @YES,
                                    @"foo": @-1}));
+}
+
+
+- (void) test072_PutExistingRevisionWithAttachment {
+    CBLDocument* doc = db[@"some-doc"];
+
+    NSData* content = [@"hi there" dataUsingEncoding: NSUTF8StringEncoding];
+    NSDictionary* props = @{@"_attachments": @{@"foo.txt": @{@"content_type": @"text/plain"}}};
+    NSDictionary* attachments = @{@"foo.txt": content};
+
+    NSError* error;
+    Assert(([doc putExistingRevisionWithProperties: props
+                                       attachments: attachments
+                                   revisionHistory: @[@"1-cafebabe"]
+                                           fromURL: nil
+                                             error: &error]));
+
+    CBLRevision* rev = doc.currentRevision;
+    Assert(rev);
+    Assert(!rev.isDeletion);
+    AssertEqual(rev.revisionID, @"1-cafebabe");
+    CBLAttachment* a = [rev attachmentNamed: @"foo.txt"];
+    Assert(a);
+    AssertEqual(a.contentType, @"text/plain");
+    AssertEqual(a.content, content);
 }
 
 


### PR DESCRIPTION
Allows revisions with attachments to be added.

Fixes #1195
